### PR TITLE
Let the model use more than 3 seconds of the prompt

### DIFF
--- a/inference_server.py
+++ b/inference_server.py
@@ -50,7 +50,7 @@ app.add_middleware(
 # Hyperparams or something.
 SAMPLE_RATE = 16000 # Don't change this
 TEMPS = (0.8, (0.4, 0.1)) # You can change this, but there's also an endpoint for it.
-
+REPLAY_SECONDS = 3 # What the user hears as context.
 
 class AudioProcessor:
     def __init__(self, model, prompt_path):
@@ -60,7 +60,8 @@ class AudioProcessor:
 
     def initialize_state(self, prompt_path):
         loaded_audio, sr = torchaudio.load(prompt_path)
-        global num_chunks
+        self.replay_seconds = REPLAY_SECONDS
+        
         if sr != SAMPLE_RATE:
             resampler = torchaudio.transforms.Resample(sr, SAMPLE_RATE)
             loaded_audio = resampler(loaded_audio)
@@ -79,22 +80,22 @@ class AudioProcessor:
                 self.next_model_audio = self.model.next_audio_from_audio(self.loaded_audio.unsqueeze(0), temps=TEMPS)
         self.prompt_buffer = None
         self.prompt_position = 0
-        self.chunks_until_live = num_chunks
+        self.chunks_until_live = int(replay_seconds * 8)
         self.initialize_prompt_buffer()
         print_colored("AudioProcessor state initialized", "green")
 
     def initialize_prompt_buffer(self):
         self.recorded_audio = self.loaded_audio
         prompt_audio = self.loaded_audio.reshape(1, 2, -1)
-        prompt_audio = prompt_audio[:, :, -num_chunks * SAMPLE_RATE:].cpu().numpy()
+        prompt_audio = prompt_audio[:, :, -(16000*self.replay_seconds):].cpu().numpy()
         prompt_audio_mono = prompt_audio.mean(axis=1)
-        self.prompt_buffer = np.array_split(prompt_audio_mono[0], num_chunks)
+        self.prompt_buffer = np.array_split(prompt_audio_mono[0], int(self.replay_seconds * 8))
         print_colored(f"Initialized prompt buffer with {len(self.prompt_buffer)} chunks", "grey")
     
     async def process_audio(self, audio_data):
         if self.chunks_until_live > 0:
             print_colored(f"Serving from prompt buffer, {self.chunks_until_live} chunks left", "grey")
-            chunk = self.prompt_buffer[num_chunks - self.chunks_until_live]
+            chunk = self.prompt_buffer[int(self.replay_seconds * 8) - self.chunks_until_live]
             self.chunks_until_live -= 1
             
             if self.chunks_until_live == 0:

--- a/inference_server.py
+++ b/inference_server.py
@@ -51,6 +51,7 @@ app.add_middleware(
 SAMPLE_RATE = 16000 # Don't change this
 TEMPS = (0.8, (0.4, 0.1)) # You can change this, but there's also an endpoint for it.
 
+
 class AudioProcessor:
     def __init__(self, model, prompt_path):
         self.model = model
@@ -59,7 +60,7 @@ class AudioProcessor:
 
     def initialize_state(self, prompt_path):
         loaded_audio, sr = torchaudio.load(prompt_path)
-        
+        global num_chunks
         if sr != SAMPLE_RATE:
             resampler = torchaudio.transforms.Resample(sr, SAMPLE_RATE)
             loaded_audio = resampler(loaded_audio)
@@ -78,22 +79,22 @@ class AudioProcessor:
                 self.next_model_audio = self.model.next_audio_from_audio(self.loaded_audio.unsqueeze(0), temps=TEMPS)
         self.prompt_buffer = None
         self.prompt_position = 0
-        self.chunks_until_live = 24
+        self.chunks_until_live = num_chunks
         self.initialize_prompt_buffer()
         print_colored("AudioProcessor state initialized", "green")
 
     def initialize_prompt_buffer(self):
         self.recorded_audio = self.loaded_audio
         prompt_audio = self.loaded_audio.reshape(1, 2, -1)
-        prompt_audio = prompt_audio[:, :, -48000:].cpu().numpy()
+        prompt_audio = prompt_audio[:, :, -num_chunks * SAMPLE_RATE:].cpu().numpy()
         prompt_audio_mono = prompt_audio.mean(axis=1)
-        self.prompt_buffer = np.array_split(prompt_audio_mono[0], 24)
+        self.prompt_buffer = np.array_split(prompt_audio_mono[0], num_chunks)
         print_colored(f"Initialized prompt buffer with {len(self.prompt_buffer)} chunks", "grey")
     
     async def process_audio(self, audio_data):
         if self.chunks_until_live > 0:
             print_colored(f"Serving from prompt buffer, {self.chunks_until_live} chunks left", "grey")
-            chunk = self.prompt_buffer[24 - self.chunks_until_live]
+            chunk = self.prompt_buffer[num_chunks - self.chunks_until_live]
             self.chunks_until_live -= 1
             
             if self.chunks_until_live == 0:

--- a/inference_server.py
+++ b/inference_server.py
@@ -80,7 +80,7 @@ class AudioProcessor:
                 self.next_model_audio = self.model.next_audio_from_audio(self.loaded_audio.unsqueeze(0), temps=TEMPS)
         self.prompt_buffer = None
         self.prompt_position = 0
-        self.chunks_until_live = int(replay_seconds * 8)
+        self.chunks_until_live = int(self.replay_seconds * 8)
         self.initialize_prompt_buffer()
         print_colored("AudioProcessor state initialized", "green")
 


### PR DESCRIPTION
Looking over the code, it seems that the server is hard-coded to use only the last 24 blocks (3 seconds) of the input prompt. This is quite strange, as even the default input prompt is longer than that. This patch should let it use the whole prompt.