### PR TITLE
Fix prompt_len in inference.ipynb, and add a `gen_len` parameter.

### DIFF
--- a/inference.ipynb
+++ b/inference.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -49,7 +49,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -160,15 +160,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def get_completion(encoded_prompt_audio, prompt_len):\n",
+    "def get_completion(encoded_prompt_audio, prompt_len, gen_len=None):\n",
     "    prompt_len_seconds = prompt_len / 8\n",
     "    print_colored(f\"Prompt length: {prompt_len_seconds:.2f}s\", \"grey\")\n",
     "    print_colored(\"Completing audio...\", \"blue\")\n",
+    "    encoded_prompt_audio = encoded_prompt_audio[:, :prompt_len]\n",
     "    with T.autocast(device_type='cuda', dtype=T.bfloat16):\n",
     "        completed_audio_batch = generator.completion(\n",
     "            encoded_prompt_audio, \n",
     "            temps=(.8, (0.5, 0.1)), # (token_temp, (categorical_temp, gaussian_temp))\n",
-    "            use_cache=True)\n",
+    "            use_cache=True,\n",
+    "            gen_len=gen_len)\n",
     "\n",
     "        completed_audio = completed_audio_batch\n",
     "        print_colored(f\"Decoding completion...\", \"blue\")\n",
@@ -195,7 +197,7 @@
     "num_completions = 10\n",
     "print_colored(f\"Generating {num_completions} completions...\", \"blue\")\n",
     "for _ in range(num_completions):\n",
-    "    completion = get_completion(encoded_prompt_audio, prompt_len)\n",
+    "    completion = get_completion(encoded_prompt_audio, prompt_len, gen_len=20*8) # 20 seconds of generation\n",
     "    display_audio(completion)"
    ]
   },


### PR DESCRIPTION
Entire prompt was being used as input, instead of only the first `prompt_len` tokens.